### PR TITLE
Fix SVG embedding + prepare for development

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,9 +28,15 @@
             preferLocalBuild = true;
             enableParallelBuilding = true;
 
+            buildInputs = [
+              pkgs.nodePackages.svgo
+            ];
+
             installPhase = ''
               mkdir $out
               cp -R src/* $out/
+              find $out/ -name '*.svg' -print0 \
+                | xargs --null --max-procs=$NIX_BUILD_CORES --max-args=1 svgo
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,13 @@
             installPhase = ''
               mkdir $out
               cp -R src/* $out/
+
+              # First delete source SVG files.
+              # This serves two purposes:
+              #   - Validate they're not accidentally used in the final build
+              #   - Skip needlessly optimizing them
+              find $out/ -name '*.src.svg' -delete
+              # Then optimize the remaining SVGs
               find $out/ -name '*.svg' -print0 \
                 | xargs --null --max-procs=$NIX_BUILD_CORES --max-args=1 svgo
             '';

--- a/flake.nix
+++ b/flake.nix
@@ -12,20 +12,6 @@
       pkgs = import nixpkgs { inherit system; };
       package = builtins.fromJSON (builtins.readFile ./package.json);
 
-      commonStylesAssets =
-        pkgs.runCommandNoCCLocal
-          "nixos-common-styles-assets-${self.lastModifiedDate}"
-          { nativeBuildInputs = [ flake.packages."${system}".embedSVG ];
-            src = ./src/assets;
-          }
-          ''
-            echo $src
-            mkdir -p ./assets
-            cp $src/* ./assets
-            chmod -R +w ./assets
-            embed-svg ./assets $out
-          '';
-
       flake = {
 
         defaultPackage."${system}" = flake.packages."${system}".commonStyles;
@@ -33,44 +19,6 @@
         checks."${system}".build = flake.defaultPackage."${system}";
 
         packages."${system}" = rec {
-
-          embedSVG = pkgs.writeScriptBin "embed-svg"
-            ''
-              #!${pkgs.bash}/bin/bash
-
-              in=$1
-              out=$2
-
-              mkdir -p $in.tmp
-
-              cp $in/*.svg $in.tmp/
-              rm -f $in.tmp/*.src.svg
-
-              echo ":: Optimizing svg files"
-              for f in $in.tmp/*.svg; do
-                echo "::  - $f"
-                ${pkgs.nodePackages.svgo}/bin/svgo $f &
-              done
-              # Wait until all `svgo` processes are done
-              # According to light testing, it is twice as fast that way.
-              wait
-
-              echo ":: Embedding SVG files"
-              source ${pkgs.stdenv}/setup
-              ls -la $in
-              cp $in/svg.less $out
-              for f in $in.tmp/*.svg; do
-                echo "::  - $f"
-                token=$(basename $f)
-                token=''${token^^}
-                token=''${token//[^A-Z0-9]/_}
-                token=SVG_''${token/%_SVG/}
-                substituteInPlace $out --replace "@$token)" "'$(cat $f)')"
-                substituteInPlace $out --replace "@$token," "'$(cat $f)',"
-              done
-
-              rm -rf $in.tmp
-            '';
 
           commonStyles = pkgs.stdenv.mkDerivation {
             name = "nixos-common-styles-${self.lastModifiedDate}";
@@ -80,17 +28,9 @@
             preferLocalBuild = true;
             enableParallelBuilding = true;
 
-            buildInputs = [
-              embedSVG
-            ];
-
             installPhase = ''
               mkdir $out
               cp -R src/* $out/
-
-              rm -rf $out/assets
-              mkdir -v $out/assets
-              cp ${commonStylesAssets} $out/assets/svg.less
             '';
           };
 

--- a/src/assets/multipurpose-wedge.svg
+++ b/src/assets/multipurpose-wedge.svg
@@ -7,7 +7,6 @@
    xmlns="http://www.w3.org/2000/svg"
    id="svg8"
    version="1.1"
-   viewBox="0 0 128 128"
    height="128"
    width="128">
   <defs

--- a/src/assets/svg.less
+++ b/src/assets/svg.less
@@ -2,8 +2,6 @@
 // ==================
 //
 // Quick notes about adding images:
-// This uses an external pipeline in default.nix to replace the @SVG_* tokens
-// with files from this directory with their name uppercased.
 
 // Inclusion of an SVG file in this file alone will not add it to the build
 // output. The mixins need to *also* be applied as rules for the SVG files to
@@ -25,7 +23,7 @@
 // You have to first declare the use of the SVG (color optional):
 //
 // ```
-// #_declare__svg(bananaphone, @SVG_BANANAPHONE, #face12);
+// #_declare__svg(bananaphone, read-file("bananaphone.svg"), #face12);
 // ```
 //
 // Then you **have** to define the actual mixin:
@@ -42,10 +40,10 @@
 // Implementation
 #_declare__svg(@name, @svg, @color: #face12) {
   .__svg_@{name} {
-    @_colorized: replace(@svg, "#face12", @color);
+    @_colorized: replace(@svg, "#face12", @color, "g");
     // ugh, that's an ugly hack... but escape() apparently doesn't deal well with percent signs.
-    @_data: replace(escape(@_colorized), "%", "PERCENT");
-    background-image: replace(~"url('data:image/svg+xml;utf8,@{_data}')", "PERCENT", "%");
+    @_data: replace(escape(@_colorized), "%", "PERCENT", "g");
+    background-image: replace(~"url('data:image/svg+xml;utf8,@{_data}')", "PERCENT", "%", "g");
   }
 }
 
@@ -55,75 +53,75 @@
 // ==============
 
 // The NixOS logo lambdaflake, alone
-#_declare__svg(lambdaflake_color, @SVG_LAMBDAFLAKE);
+#_declare__svg(lambdaflake_color, read-file("lambdaflake.svg"));
 #svg.lambdaflake.color { &:extend(.__svg_lambdaflake_color); }
 
 // The NixOS logo lambdaflake, alone
-#_declare__svg(lambdaflake_white, @SVG_LAMBDAFLAKE_WHITE);
+#_declare__svg(lambdaflake_white, read-file("lambdaflake-white.svg"));
 #svg.lambdaflake.white { &:extend(.__svg_lambdaflake_white); }
 
-#_declare__svg(nix-text_white, @SVG_TEXT_NIX, #theme.color[white]);
+#_declare__svg(nix-text_white, read-file("text-nix.svg"), #theme.color[white]);
 #svg.nix-text.white { &:extend(.__svg_nix-text_white); }
 
-#_declare__svg(nix-text_black, @SVG_TEXT_NIX, #theme.color[black]);
+#_declare__svg(nix-text_black, read-file("text-nix.svg"), #theme.color[black]);
 #svg.nix-text.black { &:extend(.__svg_nix-text_black); }
 
-#_declare__svg(nixpkgs-text_white, @SVG_TEXT_NIXPKGS, #theme.color[white]);
+#_declare__svg(nixpkgs-text_white, read-file("text-nixpkgs.svg"), #theme.color[white]);
 #svg.nixpkgs-text.white { &:extend(.__svg_nixpkgs-text_white); }
 
-#_declare__svg(nixos-text_black, @SVG_TEXT_NIXOS, #theme.color[black]);
+#_declare__svg(nixos-text_black, read-file("text-nixos.svg"), #theme.color[black]);
 #svg.nixos-text.black { &:extend(.__svg_nixos-text_black); }
 
-#_declare__svg(nixos-text_white, @SVG_TEXT_NIXOS, #theme.color[white]);
+#_declare__svg(nixos-text_white, read-file("text-nixos.svg"), #theme.color[white]);
 #svg.nixos-text.white { &:extend(.__svg_nixos-text_white); }
 
-#_declare__svg(nixos-text_black, @SVG_TEXT_NIXOS, #theme.color[black]);
+#_declare__svg(nixos-text_black, read-file("text-nixos.svg"), #theme.color[black]);
 #svg.nixos-text.black { &:extend(.__svg_nixos-text_black); }
 
-#_declare__svg(foundation-text_black, @SVG_TEXT_FOUNDATION, #theme.color[black]);
+#_declare__svg(foundation-text_black, read-file("text-foundation.svg"), #theme.color[black]);
 #svg.foundation-text.black { &:extend(.__svg_foundation-text_black); }
 
 
 // Icons
 // =====
 
-#_declare__svg(icon_search_blue-light, @SVG_SEARCH, #theme.color[blue-light]);
+#_declare__svg(icon_search_blue-light, read-file("search.svg"), #theme.color[blue-light]);
 #svg.icon.search.blue-light { &:extend(.__svg_icon_search_blue-light); }
 
-#_declare__svg(icon_search_white, @SVG_SEARCH, #theme.color[white]);
+#_declare__svg(icon_search_white, read-file("search.svg"), #theme.color[white]);
 #svg.icon.search.white { &:extend(.__svg_icon_search_white); }
 
-#_declare__svg(icon_social_twitter_white, @SVG_SOCIAL_TWITTER, #theme.color[white]);
+#_declare__svg(icon_social_twitter_white, read-file("social.twitter.svg"), #theme.color[white]);
 #svg.icon.social.twitter.white { &:extend(.__svg_icon_social_twitter_white); }
 
-#_declare__svg(icon_social_twitter_black, @SVG_SOCIAL_TWITTER, #theme.color[black]);
+#_declare__svg(icon_social_twitter_black, read-file("social.twitter.svg"), #theme.color[black]);
 #svg.icon.social.twitter.black { &:extend(.__svg_icon_social_twitter_black); }
 
-#_declare__svg(icon_social_youtube_white, @SVG_SOCIAL_YOUTUBE, #theme.color[white]);
+#_declare__svg(icon_social_youtube_white, read-file("social.youtube.svg"), #theme.color[white]);
 #svg.icon.social.youtube.white { &:extend(.__svg_icon_social_youtube_white); }
 
-#_declare__svg(icon_social_github_white, @SVG_SOCIAL_GITHUB, #theme.color[white]);
+#_declare__svg(icon_social_github_white, read-file("social.github.svg"), #theme.color[white]);
 #svg.icon.social.github.white { &:extend(.__svg_icon_social_github_white); }
 
-#_declare__svg(icon_social_reddit_black, @SVG_SOCIAL_REDDIT, #theme.color[black]);
+#_declare__svg(icon_social_reddit_black, read-file("social.reddit.svg"), #theme.color[black]);
 #svg.icon.social.reddit.black { &:extend(.__svg_icon_social_reddit_black); }
 
-#_declare__svg(icon_social_mastodon_black, @SVG_SOCIAL_MASTODON, #theme.color[black]);
+#_declare__svg(icon_social_mastodon_black, read-file("social.mastodon.svg"), #theme.color[black]);
 #svg.icon.social.mastodon.black { &:extend(.__svg_icon_social_mastodon_black); }
 
-#_declare__svg(icon_social_discord_black, @SVG_SOCIAL_DISCORD, #theme.color[black]);
+#_declare__svg(icon_social_discord_black, read-file("social.discord.svg"), #theme.color[black]);
 #svg.icon.social.discord.black { &:extend(.__svg_icon_social_discord_black); }
 
-#_declare__svg(icon_social_stackoverflow_black, @SVG_SOCIAL_STACKOVERFLOW, #theme.color[black]);
+#_declare__svg(icon_social_stackoverflow_black, read-file("social.stackoverflow.svg"), #theme.color[black]);
 #svg.icon.social.stackoverflow.black { &:extend(.__svg_icon_social_stackoverflow_black); }
 
 // Misc. elements
 // ==============
 
-#_declare__svg(icon_play, @SVG_PLAY);
+#_declare__svg(icon_play, read-file("play.svg"));
 #svg.play { &:extend(.__svg_icon_play); }
 
-#_declare__svg(icon_world, @SVG_WORLD);
+#_declare__svg(icon_world, read-file("world.svg"));
 #svg.world { &:extend(.__svg_icon_world); }
 
 // Flair
@@ -134,26 +132,26 @@
 // When scrolling on the landing page you can see some stuttering.
 
 #screen-sm-min({
-  #_declare__svg(background-outlines_blue-dark, @SVG_BACKGROUND_OUTLINES, #theme.color[blue-dark]);
+  #_declare__svg(background-outlines_blue-dark, read-file("background-outlines.svg"), #theme.color[blue-dark]);
 });
 #svg.background-outlines.blue-dark { &:extend(.__svg_background-outlines_blue-dark); }
 
 #screen-sm-min({
-  #_declare__svg(background-outlines_white, @SVG_BACKGROUND_OUTLINES, #theme.color[white]);
+  #_declare__svg(background-outlines_white, read-file("background-outlines.svg"), #theme.color[white]);
 });
 #svg.background-outlines.white { &:extend(.__svg_background-outlines_white); }
 
-#_declare__svg(big-angles-1, @SVG_BIG_ANGLES_1);
+#_declare__svg(big-angles-1, read-file("big-angles.1.svg"));
 #svg.big-angles-1 { &:extend(.__svg_big-angles-1); }
 
-#_declare__svg(big-angles-2, @SVG_BIG_ANGLES_2);
+#_declare__svg(big-angles-2, read-file("big-angles.2.svg"));
 #svg.big-angles-2 { &:extend(.__svg_big-angles-2); }
 
-#_declare__svg(title-angle_white, @SVG_TITLE_ANGLE, #theme.color[white]);
+#_declare__svg(title-angle_white, read-file("title-angle.svg"), #theme.color[white]);
 #svg.title-angle.white { &:extend(.__svg_title-angle_white); }
 
-#_declare__svg(multipurpose-wedge_blue-dark, @SVG_MULTIPURPOSE_WEDGE, #theme.color[blue-dark]);
+#_declare__svg(multipurpose-wedge_blue-dark, read-file("multipurpose-wedge.svg"), #theme.color[blue-dark]);
 #svg.multipurpose-wedge.blue-dark { &:extend(.__svg_multipurpose-wedge_blue-dark); }
 
-#_declare__svg(multipurpose-wedge_blue-lighter, @SVG_MULTIPURPOSE_WEDGE, #theme.color[blue-lighter]);
+#_declare__svg(multipurpose-wedge_blue-lighter, read-file("multipurpose-wedge.svg"), #theme.color[blue-lighter]);
 #svg.multipurpose-wedge.blue-lighter { &:extend(.__svg_multipurpose-wedge_blue-lighter); }

--- a/src/plugins/file-reader.js
+++ b/src/plugins/file-reader.js
@@ -1,0 +1,14 @@
+const readFileSync = require("fs").readFileSync;
+const path = require("path");
+
+module.exports = {
+  install: function (less, pluginManager, functions) {
+    functions.add("read-file", function (filenameNode) {
+		let filename = filenameNode.value;
+		const {currentDirectory} = this.currentFileInfo;
+		const fullFilename = path.join(currentDirectory, filename);
+
+		return readFileSync(fullFilename);
+    });
+  },
+};

--- a/src/setup.less
+++ b/src/setup.less
@@ -1,3 +1,5 @@
+@plugin "./plugins/file-reader";
+
 @import "./vendor/sdr-responsive/index";
 @import "./mixins/index";
 @import "./grid";

--- a/stories/Introduction.stories.mdx
+++ b/stories/Introduction.stories.mdx
@@ -24,12 +24,30 @@ code in the `stories/` directory.
 
 # Develop and contribute
 
-TODO:
+## Development shell
+
+```
+ $ nix-shell -A packages.x86_64-linux.storyBook
+[...]
+======================================
+= To develop run: yarn run storybook =
+======================================
+
+[nix-shell:~/.../nixos/nixos-common-styles]$ yarn run storybook
+```
+
+The storybook instance should be available at `http://localhost:6006/`.
+
+> **Tip**: If you're working from a headless system, storybook may
+> rudely try and fail to launch a browser. Work around this with:
+>
+> ```
+>  $ export BROWSER=true
+> ```
 
 ## Known issues
 
-TODO:
-- when changing svg you need to run emmbedSVG script
+*None for the time being.*
 
 # License
 


### PR DESCRIPTION
This uses a `less` plugin to read SVG files rather than clumsily embedding them with a script.

This speeds up the dev cycle a lot.

The main unsolved issue, and would be solved in the actual consumer, is how to optimize the SVG assets *in development use*. For production use it's already solved.

See:

 - https://github.com/NixOS/nixos-homepage/pull/789
 - https://github.com/NixOS/nixos-common-styles/pull/9