### PR TITLE
page-title: Fix with different DOM

### DIFF
--- a/src/components/flair.less
+++ b/src/components/flair.less
@@ -227,7 +227,7 @@
   #screen-lg-min({
     background-position: 49% 100%;
   });
-  &:first-child {
+  &:first-child, header + & {
     margin-top: -@gutter;
   }
   & > h1 {


### PR DESCRIPTION
It was assumed the DOM would be

```
main
  header
    ...
  main
    .page-title
```

Make it work with

```
main
  header
    ...
  .page-title
```