### PR TITLE
Make shell prompts unselectable

### DIFF
--- a/src/layout.less
+++ b/src/layout.less
@@ -197,6 +197,7 @@ img.inline {
 
   .shell-prompt {
     font-weight: bold;
+    user-select: none;
   }
 }
 


### PR DESCRIPTION
I noticed the shell prompts in the [installation instructions](https://nixos.org/download.html#nix-install-windows) are selectable but that's not desirable.

This change was [previously on the table](https://github.com/NixOS/nixos-homepage/pull/492) but apparently was lost somewhere.