### PR TITLE
fix: missing mastodon icon in page footer

### DIFF
--- a/src/components/footer.less
+++ b/src/components/footer.less
@@ -189,6 +189,10 @@
     .social-icon.-github a::before {
       #svg.icon.social.github.white();
     }
+
+    .social-icon.-mastodon a::before {
+      #svg.icon.social.mastodon.white();
+    }
   }
 }
 


### PR DESCRIPTION
This PR

- [x] Fix the missing Mastodon icon on nixos.org's page footer