### PR TITLE
Revert "fix: add missing mastodon white icon (#28)"

### DIFF
--- a/src/assets/svg.less
+++ b/src/assets/svg.less
@@ -103,9 +103,6 @@
 #_declare__svg(icon_social_github_white, read-file("social.github.svg"), #theme.color[white]);
 #svg.icon.social.github.white { &:extend(.__svg_icon_social_github_white); }
 
-#_declare__svg(icon_social_mastodon_white, read-file("social.mastodon.svg"), #theme.color[white]);
-#svg.icon.social.mastodon.white { &:extend(.__svg_icon_social_mastodon_white); }
-
 #_declare__svg(icon_social_reddit_black, read-file("social.reddit.svg"), #theme.color[black]);
 #svg.icon.social.reddit.black { &:extend(.__svg_icon_social_reddit_black); }
 


### PR DESCRIPTION
This reverts commit d2a7e90d79ba4287c39b24788bba653bed13e93c.

@garbas made a change, then I did a PR adding the same change, resulting in twice the same entry.